### PR TITLE
Adds support for options

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,46 @@ Transform all markdown titles with [title.sh](https://github.com/zeit/title)
 npm install --save remark-capitalize
 ```
 
+### Usage with Markdown
+
+Works as a remark plugin with either [unified](https://www.npmjs.com/package/unified) or [remark](https://www.npmjs.com/package/remark).
+
+#### Without options
+
+```js
+import markdown from 'remark-parse'
+import capitalize from 'remark-capitalize'
+import html from 'remark-html'
+
+const processedContent = await unified()
+        .use(markdown)
+        .use(capitalize)
+        .use(html)
+        .process(content)
+```
+
+#### With Options
+
+```js
+import markdown from 'remark-parse'
+import capitalize from 'remark-capitalize'
+import html from 'remark-html'
+
+// Your casing will be enforced for these words
+const options = ['iPhone', 'facebook', 'sOmeRanDOMcaSEDtiTle']
+
+const processedContent = await unified()
+        .use(markdown)
+        .use(capitalize, { options })
+        .use(html)
+        .process(content)
+```
+
 ### Usage with MDX
 
 [mdx](https://github.com/mdx-js/mdx) uses remark to transform an MDX document into JSX tags. It has support for passing plugins through the loader options:
+
+#### Without options
 
 ```js
 const remarkCapitalize = require('remark-capitalize')
@@ -23,6 +60,30 @@ const remarkCapitalize = require('remark-capitalize')
       loader: '@compositor/markdown-loader',
       options: {
         plugins: [remarkCapitalize]
+      }
+    }
+  ]
+}
+```
+
+#### With Options
+
+```js
+// Your casing will be enforced for these words
+const options = ['iPhone', 'facebook', 'sOmeRanDOMcaSEDtiTle']
+
+const remarkCapitalize = require('remark-capitalize')
+// part of webpack.config.js
+{
+  test: /\.mdx$/,
+  use: [
+    defaultLoaders.babel,
+    {
+      loader: '@compositor/markdown-loader',
+      options: {
+        plugins: [
+        [remarkCapitalize, {options}]
+        ]
       }
     }
   ]

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Works as a remark plugin with either [unified](https://www.npmjs.com/package/uni
 #### Without options
 
 ```js
+import unified from 'unified'
 import markdown from 'remark-parse'
 import capitalize from 'remark-capitalize'
 import html from 'remark-html'
@@ -29,6 +30,7 @@ const processedContent = await unified()
 #### With Options
 
 ```js
+import unified from 'unified'
 import markdown from 'remark-parse'
 import capitalize from 'remark-capitalize'
 import html from 'remark-html'

--- a/index.js
+++ b/index.js
@@ -1,11 +1,11 @@
 const title = require('title')
 const visit = require('unist-util-visit')
 
-module.exports = () => (tree, file) => {
+module.exports = ({ options } = { options: [] }) => (tree, file) => {
   visit(tree, 'heading', node => {
     visit(node, 'text', textNode => {
       const text = textNode.value ? textNode.value.trim() : ''  
-      textNode.value = title(text)
+      textNode.value = title(text, { special: options })
     })
   })
 }


### PR DESCRIPTION
👋 I've added support for options in the plugin, but passing options is of course optional, not passing any doesn't break things!

I've tested it with both markdown (through [unified](https://github.com/unifiedjs/unified)) and .mdx (through [next-mdx-remote](https://github.com/hashicorp/next-mdx-remote)), everything works out of the box!

(I also updated the documentation accordingly to showcase examples with and without options for both markdown and mdx)

Cheers 🙃